### PR TITLE
Add configurable start date to Gantt chart

### DIFF
--- a/gantt.py
+++ b/gantt.py
@@ -2,13 +2,18 @@
 import plotly.express as px
 import pandas as pd
 
-def create_gantt_chart(df):
+def create_gantt_chart(df, start_date="2025-01-01"):
+    """Create an interactive Gantt chart using Plotly.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing CPM results.
+    start_date : str or datetime-like, optional
+        The project start date used to convert ES/EF numbers to actual dates.
     """
-    Creates an interactive Gantt chart using Plotly.
-    """
-    # Plotly expects dates, so we'll create start and end dates from our day numbers
-    # We'll use a dummy start date for the project
-    project_start_date = pd.to_datetime('2025-01-01')
+    # Plotly expects real dates, so convert the provided start_date
+    project_start_date = pd.to_datetime(start_date)
 
     df_gantt = df.copy()
     df_gantt['start'] = project_start_date + pd.to_timedelta(df_gantt['ES'] - 1, unit='D')

--- a/views/project_view.py
+++ b/views/project_view.py
@@ -12,6 +12,12 @@ def show_project_view():
     Now includes Import and Export functionality.
     """
     st.header("1. Manage Your Project Tasks")
+    # Allow the user to specify the project's start date
+    start_date = st.date_input(
+        "Select Project Start Date",
+        value=pd.to_datetime("2025-01-01").date(),
+        key="project_start_date"
+    )
 
     # --- NEW: IMPORT SECTION ---
     with st.expander("Import Project from CSV File"):
@@ -80,7 +86,7 @@ def show_project_view():
                 st.info(f"**Critical Path:** {' → '.join(critical_path_tasks)}")
 
                 st.header("4. Project Gantt Chart")
-                gantt_fig = create_gantt_chart(result_df)
+                gantt_fig = create_gantt_chart(result_df, start_date=start_date)
                 st.plotly_chart(gantt_fig, use_container_width=True)
 
     # --- NEW: DOWNLOAD SECTION ---


### PR DESCRIPTION
## Summary
- allow providing `start_date` to `create_gantt_chart`
- let users pick start date in project view and pass it when creating the chart

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py cpm_logic.py gantt.py utils.py views/project_view.py`


------
https://chatgpt.com/codex/tasks/task_e_6873737c06988326be60c8f28f7e5f83