### PR TITLE
Add configurable DB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Start the Streamlit application with:
 streamlit run app.py
 ```
 
+You can change where the SQLite database is stored by setting the
+`DATABASE_PATH` environment variable before starting the app. By default the
+file `projects.db` will be created in the project directory.
+
 The web interface lets you enter tasks, durations and dependencies directly in your browser. You can also import a CSV file with the task list or export results after calculation.
 
 ## Features

--- a/database.py
+++ b/database.py
@@ -1,8 +1,9 @@
+import os
 import pandas as pd
 from sqlalchemy import create_engine, inspect, text
 
 # --- DATABASE SETUP ---
-DB_FILE = "projects.db"
+DB_FILE = os.environ.get("DATABASE_PATH", "projects.db")
 engine = create_engine(f"sqlite:///{DB_FILE}")
 
 def initialize_database():


### PR DESCRIPTION
## Summary
- allow database path to be set with `DATABASE_PATH` env var
- document the environment variable in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687382d8146c8326bf67fd5acdeba370