### PR TITLE
Add start date support

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -14,7 +14,8 @@ def get_sample_data():
         'Predecessors': [
             '', 'A', 'B', 'C', 'C', 'D,E', 'D', 'F,G'
         ],
-        'Duration': [5, 10, 15, 20, 12, 18, 9, 3]
+        'Duration': [5, 10, 15, 20, 12, 18, 9, 3],
+        'Start Date': [None] * 8
     }
     df = pd.DataFrame(data)
     return df


### PR DESCRIPTION
## Summary
- extend DB schema with `start_date`
- update utils sample data to include `Start Date`
- allow Start Date editing with date picker in project view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ad1da5148326828ed34982ab696e