### PR TITLE
Handle missing start_date column

### DIFF
--- a/database.py
+++ b/database.py
@@ -25,7 +25,15 @@ def initialize_database():
                     UNIQUE(project_id, task_id_str)
                 );
             """))
+            connection.commit()
             print("Database initialized and 'tasks' table created.")
+        else:
+            inspector = inspect(engine)
+            columns = [col["name"] for col in inspector.get_columns("tasks")]
+            if "start_date" not in columns:
+                connection.execute(text("ALTER TABLE tasks ADD COLUMN start_date TEXT"))
+                connection.commit()
+                print("'start_date' column added to existing tasks table.")
 
 def get_project_data_from_db(project_id=1):
     """


### PR DESCRIPTION
## Summary
- ensure initialize_database adds the start_date column if missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873b0362bdc83269844322f713ca352